### PR TITLE
build: Add option to compress precompiled odex with gzip

### DIFF
--- a/core/dex_preopt_libart.mk
+++ b/core/dex_preopt_libart.mk
@@ -58,6 +58,13 @@ define get-odex-file-path
 $(dir $(2))$(1)/$(basename $(notdir $(2))).odex
 endef
 
+# Returns the path to the .odex.gz file
+# $(1): the arch name.
+# $(2): the full path (including file name) of the corresponding .jar or .apk.
+define get-odex-comp-path
+$(dir $(2))$(1)/$(basename $(notdir $(2))).odex.gz
+endef
+
 # Returns the path to the image file (such as "/system/framework/<arch>/boot.art"
 # $(1): the arch name (such as "arm")
 # $(2): the image location (such as "/system/framework/boot.art")

--- a/core/dex_preopt_odex_install.mk
+++ b/core/dex_preopt_odex_install.mk
@@ -46,6 +46,7 @@ endif
 
 built_odex :=
 installed_odex :=
+compressed_odex :=
 built_installed_odex :=
 ifdef LOCAL_DEX_PREOPT
 dexpreopt_boot_jar_module := $(filter $(DEXPREOPT_BOOT_JARS_MODULES),$(LOCAL_MODULE))
@@ -108,7 +109,9 @@ endif
 
 # Compile apps with position-independent code if WITH_DEXPREOPT_PIC=true
 ifeq (true,$(WITH_DEXPREOPT_PIC))
+ifeq (false,$(WITH_DEXPREOPT_COMP))
   LOCAL_DEX_PREOPT_FLAGS += --compile-pic
+endif
 endif
 
 $(built_odex): PRIVATE_DEX_PREOPT_FLAGS := $(LOCAL_DEX_PREOPT_FLAGS)
@@ -120,13 +123,22 @@ $(installed_odex) : $(dir $(LOCAL_INSTALLED_MODULE))%$(notdir $(word 1,$(install
     | $(ACP)
 	@echo -e ${CL_CYN}"Install: $@"${CL_RST}
 	$(copy-file-to-target)
+
+# Ugly syntax - See the definition get-odex-comp-path.
+$(compressed_odex) : $(dir $(LOCAL_INSTALLED_MODULE))%$(notdir $(word 1,$(compressed_odex))) \
+                   : $(dir $(LOCAL_BUILT_MODULE))%$(notdir $(word 1,$(built_odex))) \
+    | $(MINIGZIP)
+	$(hide) mkdir -p $(dir $@)
+	$(MINIGZIP) -9 < $< > $@
 endif
 
-# Add the installed_odex to the list of installed files for this module.
+# Add the installed_odex and compressed_odex to the list of installed files for this module.
+ALL_MODULES.$(my_register_name).INSTALLED += $(compressed_odex)
 ALL_MODULES.$(my_register_name).INSTALLED += $(installed_odex)
 ALL_MODULES.$(my_register_name).BUILT_INSTALLED += $(built_installed_odex)
 
 # Make sure to install the .odex when you run "make <module_name>"
+$(my_register_name): $(compressed_odex)
 $(my_register_name): $(installed_odex)
 
 endif # LOCAL_DEX_PREOPT

--- a/core/setup_one_odex.mk
+++ b/core/setup_one_odex.mk
@@ -18,7 +18,16 @@
 # Input variables: my_2nd_arch_prefix
 # Output(modified) variables: built_odex, installed_odex, built_installed_odex
 
+my_local_odex_comp :=
+
+ifneq (false,$(WITH_DEXPREOPT_COMP))
+ifneq ($(filter %.apk,$(LOCAL_INSTALLED_MODULE)),)
+my_local_odex_comp := true
+endif
+endif
+
 my_built_odex := $(call get-odex-file-path,$($(my_2nd_arch_prefix)DEX2OAT_TARGET_ARCH),$(LOCAL_BUILT_MODULE))
+
 ifdef LOCAL_DEX_PREOPT_IMAGE_LOCATION
 my_dex_preopt_image_location := $(LOCAL_DEX_PREOPT_IMAGE_LOCATION)
 else
@@ -32,8 +41,16 @@ $(my_built_odex) : $($(my_2nd_arch_prefix)DEXPREOPT_ONE_FILE_DEPENDENCY_BUILT_BO
     $(DEXPREOPT_ONE_FILE_DEPENDENCY_TOOLS) \
     $(my_dex_preopt_image_filename)
 
+ifeq (true,$(my_local_odex_comp))
+my_installed_odex := $(call get-odex-comp-path,$($(my_2nd_arch_prefix)DEX2OAT_TARGET_ARCH),$(LOCAL_INSTALLED_MODULE))
+else
 my_installed_odex := $(call get-odex-file-path,$($(my_2nd_arch_prefix)DEX2OAT_TARGET_ARCH),$(LOCAL_INSTALLED_MODULE))
+endif
 
 built_odex += $(my_built_odex)
+ifeq (true,$(my_local_odex_comp))
+compressed_odex += $(my_installed_odex)
+else
 installed_odex += $(my_installed_odex)
+endif
 built_installed_odex += $(my_built_odex):$(my_installed_odex)


### PR DESCRIPTION
To reduce /system size, we add the option to compress odex files

Run make with WITH_DEXPREOPT_COMP=true to get odex compressed.

This patch needs to be supported by frameworks/native/cmds/installd

Change-Id: I8c4e6a30c49a1433f8af61a84ece85c92004da62
Depends-Change-Id: Ifa61af39c5644529699c17d6c19ef03742989afd
Signed-off-by: Julien Delayen julien.delayen@intel.com
Signed-off-by: Yevgeny Rouban yevgeny.y.rouban@intel.com
